### PR TITLE
Keep backwards compatibility

### DIFF
--- a/PythonQuandl.cs
+++ b/PythonQuandl.cs
@@ -14,8 +14,9 @@
 */
 
 using System;
+using QuantConnect.DataSource;
 
-namespace QuantConnect.DataSource
+namespace QuantConnect.Python
 {
     /// <summary>
     /// Dynamic data class for Python algorithms.

--- a/Quandl.cs
+++ b/Quandl.cs
@@ -14,8 +14,9 @@
 */
 
 using System;
+using QuantConnect.DataSource;
 
-namespace QuantConnect.DataSource
+namespace QuantConnect.Data.Custom
 {
     /// <summary>
     /// Quandl Data Type (Deprecated, Use NasdaqDataLink instead.)

--- a/tests/NasdaqDataLinkTests.cs
+++ b/tests/NasdaqDataLinkTests.cs
@@ -23,6 +23,7 @@ using Newtonsoft.Json;
 using Python.Runtime;
 using NUnit.Framework;
 using QuantConnect.Data;
+using QuantConnect.Data.Custom;
 using QuantConnect.DataSource;
 
 namespace QuantConnect.DataLibrary.Tests


### PR DESCRIPTION
Some users use algorithms with pre-`AlgorithmImports.py` LEAN versions
This solves this problem:
![image](https://user-images.githubusercontent.com/47573394/149398133-c1a76e3a-5812-49b9-b852-b99f26f1863c.png)
