### PR TITLE
Refacotr: use new Nasdaq url path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-20.04
-    container:
-        image: quantconnect/lean:foundation
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Free space
+        run: df -h && rm -rf /opt/hostedtoolcache* && df -h
 
       - name: Checkout Lean Same Branch
         id: lean-same-branch
@@ -33,11 +35,16 @@ jobs:
       - name: Move Lean
         run: mv Lean ../Lean
 
-      - name: BuildDataSource
-        run: dotnet build ./QuantConnect.DataSource.csproj /p:Configuration=Release /v:quiet /p:WarningLevel=1
-
-      - name: BuildTests
-        run: dotnet build ./tests/Tests.csproj /p:Configuration=Release /v:quiet /p:WarningLevel=1
-
-      - name: Run Tests
-        run: dotnet test ./tests/bin/Release/net6.0/Tests.dll
+      - name: Run Image
+        uses: addnab/docker-run-action@v3
+        with:
+          image: quantconnect/lean:foundation
+          options: -v /home/runner/work:/__w --workdir /__w/Lean.DataSource.Polygon/Lean.DataSource.Polygon -e QC_POLYGON_API_KEY=${{ secrets.POLYGON_API_KEY }} -e QC_JOB_USER_ID=${{ secrets.JOB_USER_ID }} -e QC_API_ACCESS_TOKEN=${{ secrets.API_ACCESS_TOKEN }} -e QC_JOB_ORGANIZATION_ID=${{ secrets.JOB_ORGANIZATION_ID }}
+          shell: bash
+          run: |
+            # Build NasdaqDataLink
+            dotnet build ./QuantConnect.DataSource.csproj /p:Configuration=Release /v:quiet /p:WarningLevel=1
+            # Build Tests NasdaqDataLink
+            dotnet build ./tests/Tests.csproj /p:Configuration=Release /v:quiet /p:WarningLevel=1
+            # Run Tests NasdaqDataLink
+            dotnet test ./tests/bin/Release/net6.0/Tests.dll

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build & Test
 
 on:
   push:
-    branches: ['*']
+    branches: ["*"]
   pull_request:
     branches: [master]
 
@@ -39,7 +39,7 @@ jobs:
         uses: addnab/docker-run-action@v3
         with:
           image: quantconnect/lean:foundation
-          options: -v /home/runner/work:/__w --workdir /__w/Lean.DataSource.Polygon/Lean.DataSource.Polygon -e QC_POLYGON_API_KEY=${{ secrets.POLYGON_API_KEY }} -e QC_JOB_USER_ID=${{ secrets.JOB_USER_ID }} -e QC_API_ACCESS_TOKEN=${{ secrets.API_ACCESS_TOKEN }} -e QC_JOB_ORGANIZATION_ID=${{ secrets.JOB_ORGANIZATION_ID }}
+          options: -v /home/runner/work:/__w --workdir /__w/Lean.DataSource.NasdaqDataLink/Lean.DataSource.NasdaqDataLink
           shell: bash
           run: |
             # Build NasdaqDataLink

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Free space
-        run: df -h && rm -rf /opt/hostedtoolcache* && df -h
+        run: df -h && sudo rm -rf /usr/local/lib/android && sudo rm -rf /opt/ghc && rm -rf /opt/hostedtoolcache* && df -h
 
       - name: Checkout Lean Same Branch
         id: lean-same-branch

--- a/NasdaqDataLink.cs
+++ b/NasdaqDataLink.cs
@@ -113,8 +113,8 @@ namespace QuantConnect.DataSource
         /// <returns>STRING API Url for Nasdaq Data Link.</returns>
         public override SubscriptionDataSource GetSource(SubscriptionDataConfig config, DateTime date, bool isLiveMode)
         {
-            var source = $"https://data.nasdaq.com/api/v3/datasets/{config.Symbol.Value}.csv?order=asc&api_key={_authCode}";
-            return new SubscriptionDataSource(source, SubscriptionTransportMedium.RemoteFile);
+            var source = $"https://data.nasdaq.com/api/v3/datatables/{config.Symbol.Value}.csv?api_key={_authCode}";
+            return new SubscriptionDataSource(source, SubscriptionTransportMedium.RemoteFile) { Sort = true };
         }
 
         /// <summary>
@@ -145,9 +145,9 @@ namespace QuantConnect.DataSource
                 return null;
             }
 
-            data.Time = DateTime.ParseExact(csv[0], "yyyy-MM-dd", CultureInfo.InvariantCulture);
+            data.Time = DateTime.ParseExact(csv[2], "yyyy-MM-dd", CultureInfo.InvariantCulture);
 
-            for (var i = 1; i < csv.Length; i++)
+            for (var i = 3; i < csv.Length; i++)
             {
                 var value = csv[i].ToDecimal();
                 data.SetProperty(_propertyNames[i], value);

--- a/NasdaqDataLink.cs
+++ b/NasdaqDataLink.cs
@@ -37,7 +37,7 @@ namespace QuantConnect.DataSource
         /// <summary>
         /// The API key used for authentication with the external service (Nasdaq).
         /// </summary>
-        private static string _apiKey = "your_api_key";
+        private static string _apiKey = string.Empty;
 
         /// <summary>
         /// Stores the index of the "date" field in the CSV file.

--- a/NasdaqDataLink.cs
+++ b/NasdaqDataLink.cs
@@ -162,7 +162,7 @@ namespace QuantConnect.DataSource
                     data.Time = dateTime;
                     data.SetProperty(_propertyNames[i], dateTime);
                 }
-                else if (decimal.TryParse(csv[i], NumberStyles.AllowExponent | NumberStyles.Float, CultureInfo.InvariantCulture, out var value))
+                else if (decimal.TryParse(csv[i], NumberStyles.Any, CultureInfo.InvariantCulture, out var value))
                 {
                     data.SetProperty(_propertyNames[i], value);
                 }

--- a/NasdaqDataLink.cs
+++ b/NasdaqDataLink.cs
@@ -33,63 +33,35 @@ namespace QuantConnect.DataSource
     [ProtoContract(SkipConstructor = true)]
     public class NasdaqDataLink : DynamicData
     {
-        /// <summary>
-        /// The API key used for authentication with the external service (Nasdaq).
-        /// </summary>
-        private static string _apiKey = string.Empty;
+        private static string _authCode = "your_api_key";
+        private bool _isInitialized;
 
         /// <summary>
-        /// Stores the index of the "date" field in the CSV file.
+        /// Stores the index of the "date" field in the CSV file headers.
         /// </summary>
-        /// <remarks>
-        /// This field is assigned the position of the "date" column when iterating through the CSV headers. 
-        /// It is used to locate and parse date-related data.
-        /// </remarks>
         private int _indexDateTime;
 
         /// <summary>
         /// Stores the date format string used for parsing date values.
-        /// The format is set dynamically based on the property name (e.g., "yyyy-MM-dd" for a full date or "yyyy" for just a year).
+        /// The format is set dynamically based on the property name (e.g., "yyyy", "yyyy-MM", "yyyy-MM-dd").
         /// </summary>
         private string parsingFormatDateTime;
 
-        /// <summary>
-        /// Indicates whether the initialization process has been completed.
-        /// </summary>
-        /// <remarks>
-        /// This field ensures that the CSV header parsing and initialization of property names
-        /// only happens once during the execution.
-        /// </remarks>
-        private bool _isInitialized;
+        private readonly List<string> _propertyNames = new List<string>();
 
-        private readonly List<string> _propertyNames = new();
-
-        /// <summary>
-        /// A list of default column names used by the NasdaqDataLink API for identifying key financial data.
-        /// </summary>
-        /// <remarks>
-        /// If another column name option is not explicitly provided, the NasdaqDataLink API will attempt to use one of the following
-        /// default keywords: "close", "price", "settle", or "value" to retrieve financial data.
-        /// </remarks>
+        // The NasdaqDataLink will use one of these column names if they are available and another option is not provided
         private readonly List<string> _keywords = new List<string> { "close", "price", "settle", "value" };
 
         /// <summary>
-        /// Specifies the name of the column to be used for the field representing the value.
+        /// Name of the column is going to be used for the field Value
         /// </summary>
-        /// <remarks>
-        /// This property is set within the Python class constructor that inherits from <c>NasdaqDataLink</c>. 
-        /// It allows the user to define a specific column to be used as the value when interacting with the class in Python.
-        /// </remarks>
-        protected string ValueColumnName { set => SetValueColumnName(value); }
-
-        /// <summary>
-        /// Indicates whether the Nasdaq Data Link API key has been set.
-        /// </summary>
-        /// <remarks>
-        /// This flag is used to check if the API key has been configured. It returns <c>true</c> if the key has been set, 
-        /// and <c>false</c> otherwise.
-        /// </remarks>
-        public static bool IsApiKeySet { get; private set; }
+        /// <remarks>This field will be set in the Python class constructor
+        /// which inherits from NasdaqDataLink. It was made to allow the user to
+        /// set a specified column to be used as a value when working in Python.</remarks>
+        protected string ValueColumnName
+        {
+            set => SetValueColumnName(value);
+        }
 
         /// <summary>
         /// Static constructor for the <see cref="NasdaqDataLink"/> class
@@ -105,7 +77,7 @@ namespace QuantConnect.DataSource
 
             if (!string.IsNullOrEmpty(potentialNasdaqToken))
             {
-                SetApiKey(potentialNasdaqToken);
+                SetAuthCode(potentialNasdaqToken);
             }
             else
             {
@@ -113,7 +85,7 @@ namespace QuantConnect.DataSource
 
                 if (!string.IsNullOrEmpty(potentialQuandlToken))
                 {
-                    SetApiKey(potentialQuandlToken);
+                    SetAuthCode(potentialQuandlToken);
                     Log.Error("NasdaqDataLink(): 'quandl-auth-token' is obsolete please use 'nasdaq-auth-token' instead.");
                 }
             }
@@ -136,6 +108,15 @@ namespace QuantConnect.DataSource
         }
 
         /// <summary>
+        /// Flag indicating whether or not the Nasdaq Data Link auth code has been set yet
+        /// </summary>
+        public static bool IsAuthCodeSet
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
         /// Using the Nasdaq Data Link V3 API automatically set the URL for the dataset.
         /// </summary>
         /// <param name="config">Subscription configuration object</param>
@@ -144,12 +125,7 @@ namespace QuantConnect.DataSource
         /// <returns>STRING API Url for Nasdaq Data Link.</returns>
         public override SubscriptionDataSource GetSource(SubscriptionDataConfig config, DateTime date, bool isLiveMode)
         {
-            if (string.IsNullOrEmpty(_apiKey))
-            {
-                throw new ArgumentException($"{nameof(NasdaqDataLink)}.{nameof(GetSource)}: API key cannot be null or empty.", nameof(_apiKey));
-            }
-
-            var source = $"https://data.nasdaq.com/api/v3/datatables/{config.Symbol.Value}.csv?api_key={_apiKey}";
+            var source = $"https://data.nasdaq.com/api/v3/datatables/{config.Symbol.Value}.csv?api_key={_authCode}";
             return new SubscriptionDataSource(source, SubscriptionTransportMedium.RemoteFile) { Sort = true };
         }
 
@@ -239,23 +215,15 @@ namespace QuantConnect.DataSource
         }
 
         /// <summary>
-        /// Sets the API key for the Nasdaq Data Link.
+        /// Set the auth code for the Nasdaq Data Link set to the QuantConnect auth code.
         /// </summary>
-        /// <param name="apiKey">The API key to be used for authentication. Must not be null or whitespace.</param>
-        /// <remarks>
-        /// This method assigns the provided API key to the internal field if it is valid (non-null and non-whitespace). 
-        /// Once the key is set, the <c>IsApiKeySet</c> flag is updated to <c>true</c>.
-        /// </remarks>
-        public static void SetApiKey(string apiKey)
+        /// <param name="authCode"></param>
+        public static void SetAuthCode(string authCode)
         {
-            if (string.IsNullOrWhiteSpace(apiKey))
-            {
-                Log.Trace($"{nameof(NasdaqDataLink)}.{nameof(SetApiKey)}: The API key for Nasdaq Data Link was not provided or is empty.");
-                return;
-            }
+            if (string.IsNullOrWhiteSpace(authCode)) return;
 
-            _apiKey = apiKey;
-            IsApiKeySet = true;
+            _authCode = authCode;
+            IsAuthCodeSet = true;
         }
 
         /// <summary>

--- a/tests/NasdaqDataLinkTests.cs
+++ b/tests/NasdaqDataLinkTests.cs
@@ -97,6 +97,43 @@ namespace QuantConnect.DataLibrary.Tests
             Assert.AreEqual(expected, data.Value);
         }
 
+        [TestCase("QDL/FON", "contract_code,type,date,market_participation,producer_merchant_processor_user_longs,producer_merchant_processor_user_shorts,swap_dealer_longs,swap_dealer_shorts,swap_dealer_spreads,money_manager_longs,money_manager_shorts,money_manager_spreads,other_reportable_longs,other_reportable_shorts,other_reportable_spreads,total_reportable_longs,total_reportable_shorts,non_reportable_longs,non_reportable_shorts", "967654,FO_OLD,2017-12-26,27122.0,9984.0,19225.0,1945.0,1405.0,1596.0,0.0,150.0,0.0,8316.0,597.0,1464.0,23305.0,24437.0,3817.0,2685.0", Description = "Commodity Futures Trading Commission Reports: Futures and Options Metrics: OI and NT")]
+        [TestCase("QDL/LFON", "contract_code,type,date,market_participation,non_commercial_longs,non_commercial_shorts,non_commercial_spreads,commercial_longs,commercial_shorts,total_reportable_longs,total_reportable_shorts,non_reportable_longs,non_reportable_shorts", "ZB9105,FO_L_OLD_OI,2018-11-27,100.0,68.6,68.6,31.4,0.0,0.0,100.0,100.0,0.0,0.0", Description = "Commodity Futures Trading Commission Reports: Legacy Futures and Options Metrics: OI and NT")]
+        [TestCase("QDL/FCR", "contract_code,type,date,largest_4_longs_gross,largest_4_shorts_gross,largest_8_longs_gross,largest_8_shorts_gross,largest_4_longs_net,largest_4_shorts_net,largest_8_longs_net,largest_8_shorts_net", "ZB9105,F_L_ALL_CR,2018-10-30,87.6,99.0,97.8,100.0,13.7,16.1,15.8,16.3", Description = "Commodity Futures Trading Commission Reports: Futures and Options Metrics: CR")]
+        [TestCase("QDL/BCHAIN", "code,date,value", "TRFUS,2020-08-28,1197064.8298", Description = "Bitcoin Data Insights")]
+        [TestCase("QDL/ODA", "indicator,date,value", "ZWE_PPPSH,2018-12-31,0.028", Description = "IMF Cross Country Macroeconomic Statistics")]
+        [TestCase("QDL/ODA", "indicator,date,value", "ZWE_PPPSH,1997-12-31,", Description = "IMF Cross Country Macroeconomic Statistics")]
+        [TestCase("QDL/JODI", "energy,code,country,date,value,notes", "OIL,TPSDKT,ZAF,2024-04-30,0.0000,3", Description = "JODI Oil World Database")]
+        [TestCase("QDL/JODI", "energy,code,country,date,value,notes", "OIL,TPSDKT,TTO,2005-03-31,,3", Description = "JODI Oil World Database")]
+        [TestCase("QDL/BITFINEX", "code,date,high,low,mid,last,bid,ask,volume", "ZRXUSD,2024-09-13,0.30349,0.28357,0.29886,0.29922,0.29865,0.29907,236649.194029", Description = "Bitfinex Crypto Coins Exchange Rate")]
+        [TestCase("QDL/BITFINEX", "code,date,high,low,mid,last,bid,ask,volume", "ZRXBTC,2022-02-20,1.493e-05,1.448e-05,1.487e-05,1.489e-05,1.485e-05,1.489e-05,6907.80795766", Description = "Bitfinex Crypto Coins Exchange Rate")]
+        [TestCase("QDL/OPEC", "date,value", "2024-01-12,80.18", Description = "Organization of the Petroleum Exporting Countries")]
+        [TestCase("QDL/LME", "item_code,country_code,date,opening_stock,delivered_in,delivered_out,closing_stock,open_tonnage,cancelled_tonnage", "ZIJ,UTO,2024-07-12,0.0,0.0,0.0,0.0,0.0,0.0", Description = "Metal Stocks Breakdown Report")]
+        [TestCase("QDL/LME", "item_code,country_code,date,opening_stock,delivered_in,delivered_out,closing_stock,open_tonnage,cancelled_tonnage", "ZII,UNE,2020-07-23,26075.0,0.0,0.0,26075.0,14425.0,11650.0", Description = "Metal Stocks Breakdown Report")]
+        [TestCase("ZILLOW/DATA", "indicator_id,region_id,date,value", "ZSFH,99999,2024-04-30,481777.608668988", Description = "Zillow Real Estate Data")]
+        [TestCase("ZILLOW/DATA", "indicator_id,region_id,date,value", "ZSFH,99993,2008-07-31,139908.0", Description = "Zillow Real Estate Data")]
+        [TestCase("WB/DATA", "series_id,country_code,country_name,year,value", "VC.PKP.TOTL.UN,XKX,Kosovo,2017,357.0", Description = "World Bank Data")]
+        [TestCase("WB/DATA", "series_id,country_code,country_name,year,value", "VC.IHR.PSRC.P5,ALB,Albania,1998,20.4196832752429", Description = "World Bank Data")]
+        [TestCase("WASDE/DATA", "code,report_month,region,commodity,item,year,period,value,min_value,max_value", "WHEAT_WORLD_19,2024-02,World Less China,Wheat,Production,2023/24 Proj.,Jan,648.32,,", Description = "World Agricultural Supply and Demand Estimates")]
+        [TestCase("WASDE/DATA", "code,report_month,region,commodity,item,year,period,value,min_value,max_value", "WHEAT_WORLD_19,2022-08,N. Africa 7/,Wheat,Production,2022/23 Proj.,Jul,17.15,,", Description = "World Agricultural Supply and Demand Estimates")]
+        [TestCase("WASDE/DATA", "code,report_month,region,commodity,item,year,period,value,min_value,max_value", "WHEAT_WORLD_19,2021-05,Brazil,Wheat,Beginning Stocks,2021/22 Proj.,May,0.64,,", Description = "World Agricultural Supply and Demand Estimates")]
+        public void CreateDifferentNasdaqDataSymbolWithVariousProperties(string nasdaqDataName, string csvHeader, string csvData)
+        {
+            var nasdaq = new NasdaqDataLink();
+
+            var symbol = Symbol.Create(nasdaqDataName, SecurityType.Base, "empty");
+
+            var config = new SubscriptionDataConfig(typeof(NasdaqDataLink), symbol, Resolution.Daily, TimeZones.Utc, TimeZones.Utc, true, true, false, true);
+
+            var dateTimeUtcNow = DateTime.UtcNow;
+
+            nasdaq.Reader(config, csvHeader, dateTimeUtcNow, false);
+            var data = nasdaq.Reader(config, csvData, dateTimeUtcNow, false);
+
+            Assert.That(data.Time, Is.Not.EqualTo(default));
+            Assert.GreaterOrEqual(data.Value, 0m);
+        }
+
         [Test]
         public void PythonValueColumn()
         {


### PR DESCRIPTION
#### Description
The [Nasdaq Data Link](https://data.nasdaq.com/search) provides much data with different parameters. The current PR refactor endpoint of `GetSource()` and fix parsing data in `Reader()` using `.csv` format file.

#### Related PRs
- https://github.com/QuantConnect/Lean/pull/8352
#### Related Issue
closes #6 - use property `new SubscriptionDataSource() { Sort = true }`
closes #7 - use generic parsing `.csv` format of different Nasdaq data.

#### Motivation and Context
Allow users to use this data source for their algorithms in Lean.

#### How Has This Been Tested?
- fix CI\CD workflow file.
- use specific `[TestCases(...)]` with a different `.csv` header and row to handle all available free data on Nasdaq.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`